### PR TITLE
(Very minor) Correct r-universe installation instructions

### DIFF
--- a/README.Rmd
+++ b/README.Rmd
@@ -33,7 +33,7 @@ which is itself built on the Rust crate [`ast-grep`](https://ast-grep.github.io/
 ## Installation
 
 ``` r
-install.packages('flint', repos = c('https://etiennebacher.r-universe.dev'))
+install.packages('flint', repos = c('https://etiennebacher.r-universe.dev', 'https://cloud.r-project.org'))
 ```
 
 ## Usage

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ itself built on the Rust crate
 ## Installation
 
 ``` r
-install.packages('flint', repos = c('https://etiennebacher.r-universe.dev'))
+install.packages('flint', repos = c('https://etiennebacher.r-universe.dev', 'https://cloud.r-project.org'))
 ```
 
 ## Usage


### PR DESCRIPTION
This is super minor; and kudos for a tremendous package.

Your installation instructions from r-universe are currently incomplete because if someone is missing CRAN dependencies then they additionally need to specify a CRAN repos in the `install.packages()` call - this is why Jeroen always includes this in the installation instructions on each r-universe package page, i.e., on <https://etiennebacher.r-universe.dev/flint>


![CleanShot 2024-10-14 at 09 02 36@2x](https://github.com/user-attachments/assets/dc67f173-d167-4c58-98ee-6eaf7c41b870)
