### PR TITLE
(Very minor) End .Rbuildignore with a newline

### DIFF
--- a/R/setup.R
+++ b/R/setup.R
@@ -29,7 +29,7 @@ setup_flint <- function(path = ".") {
   if (!already_in) {
     cat(
       "\n\n# flint files
-^flint$",
+^flint$\n",
       file = ".Rbuildignore",
       append = TRUE
     )


### PR DESCRIPTION
I noticed that the addition to .Rbuildignore didn't end the file with a newline.

I'm nt sure this is really necessary, but probably safer to do this.